### PR TITLE
Fix figure examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Example:
 #import "@preview/algorithmic:1.0.0"
 #import algorithmic: style-algorithm, algorithm-figure
 #show: style-algorithm
-#algorithm-figure("Binary Search",{
+#algorithm-figure("Binary Search", {
   import algorithmic: *
   Procedure(
     "Binary-Search",
@@ -112,7 +112,7 @@ with the `style-algorithm` show rule.
 ```typst
 #import algorithmic: algorithm-figure, style-algorithm
 #show: style-algorithm // Do not forget!
-#algorithm-figure("Variable Assignment",{
+#algorithm-figure("Variable Assignment", {
   import algorithmic: *
   Assign[$x$][$y$]
 })

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Example:
 #import "@preview/algorithmic:1.0.0"
 #import algorithmic: style-algorithm, algorithm-figure
 #show: style-algorithm
-#algorithm-figure({
+#algorithm-figure("Binary Search",{
   import algorithmic: *
   Procedure(
     "Binary-Search",
@@ -112,13 +112,10 @@ with the `style-algorithm` show rule.
 ```typst
 #import algorithmic: algorithm-figure, style-algorithm
 #show: style-algorithm // Do not forget!
-#algorithm-figure(
-  "Variable Assignement",
-  {
-    import algorithmic: *
-    Assign[$x$][$y$]
-  },
-)
+#algorithm-figure("Variable Assignment",{
+  import algorithmic: *
+  Assign[$x$][$y$]
+})
 ```
 
 #### Control flow


### PR DESCRIPTION
The main example in the README currently does not compile, since it lacks a title. This commit fixes this and puts the two examples in the same style. Typo fix too.

**Note:** Personally, I think I'd get rid of the `import algorithmic: *` inside the figures and instead just replace the initial import statement with it. Keeping it in case you find it more convenient this way, to scope imports of internal stuff I assume.