### PR TITLE
fix: update `Assign` to handle array input to the second argument

### DIFF
--- a/algorithmic.typ
+++ b/algorithmic.typ
@@ -204,7 +204,7 @@
 }
 
 // Instructions
-#let Assign(var, val) = (var + " " + $<-$ + " " + val,)
+#let Assign(var, val) = (var + " " + $<-$ + " " + arraify(val).join(", "),)
 #let Return(arg) = (strong("return") + " " + arg,)
 #let Terminate = (smallcaps("terminate"),)
 #let Break = (smallcaps("break"),)

--- a/tests/assign/test.typ
+++ b/tests/assign/test.typ
@@ -1,7 +1,16 @@
 #import "../../algorithmic.typ"
 #import algorithmic: algorithm
-#set page(margin: .1cm, width: 4cm, height: auto)
+#set page(margin: .1cm, width: 5cm, height: auto)
 #algorithm({
   import algorithmic: *
+
+  let Foo = Fn.with("foo")
+  let Bar = Call.with("bar")
+
   Assign[$x$][$y$]
+  Assign($x$, $y$)
+  Assign($x$, Foo[$y$, $z$])
+  Assign($x$, Foo[$y$])
+  Assign($x$, Bar[$y$])
+  Assign($x$, Bar[$y$, $z$])
 })


### PR DESCRIPTION
Update the `Assign` definition to handle cases where the value is an array, joining elements with a comma.

Also, expanded tests to expand coverage of additional edge cases.

I am leaving this as a draft PR while I continue to look into any related scenarios.