### PR TITLE
fix: respect style-algorithm scope and placement

### DIFF
--- a/algorithmic.typ
+++ b/algorithmic.typ
@@ -46,8 +46,6 @@
     )
     let _placement = placement
     let _scope = scope
-    if it.placement != none { _placement = it.placement }
-    if it.scope != "column" { _scope = it.scope }
     if _placement != none {
       place(_placement, scope: _scope, float: true, algo)
     } else {


### PR DESCRIPTION
Hi,

If a template has a `set figure(scope: "parent", placement: top)` rule (or similar), the options set in the `style-algorithm` method are overwridden by the values taken from the figure.

Removing the lines that default the placement and scope of the block to the values from the figure fixes this.

Hope this helps :)